### PR TITLE
Added workaround for SAM ambiguity on 2.12

### DIFF
--- a/core/src/main/scala/knobs/Configured.scala
+++ b/core/src/main/scala/knobs/Configured.scala
@@ -33,7 +33,9 @@ trait Configured[A] {
 }
 
 object Configured {
-  def apply[A:Configured]: Configured[A] = implicitly[Configured[A]]
+
+  // second parameter (of any non-Unit) is required to get around SAM-derived ambiguities
+  def apply[A](implicit A: Configured[A], T: Trivial): Configured[A] = A
 
   def apply[A](f: CfgValue => Option[A]): Configured[A] = new Configured[A] {
     def apply(v: CfgValue) = f(v)

--- a/core/src/main/scala/knobs/Trivial.scala
+++ b/core/src/main/scala/knobs/Trivial.scala
@@ -1,0 +1,7 @@
+package knobs
+
+sealed trait Trivial
+
+object Trivial {
+  implicit val trivial: Trivial = new Trivial {}
+}


### PR DESCRIPTION
The problem, fundamentally, is that the compiler is resolving the implicit `Configured` instance and then attempting to resolving the typing on the subsequent application of the `apply` method.  When it does that, SAM checking kicks in and it sees `Configured` as a valid instantiation of the *second* `apply` overload (the one which takes a function), and thus both branches of the overload are applicable at the call site.  It's less confusing to see if you remove the implicit sugar.

At any rate, there are really only three solutions here:

- Rename the second `apply` to avoid the overloading (e.g. maybe `lift`?)
- Add a trivial implicit to the first `apply` to force the signature by arity (the approach I took)
- Add a dummy abstract method to `Configured` which prevents SAM from being applicable