### PR TITLE
sleep to prevent deadlock in 2.12

### DIFF
--- a/zookeeper/src/test/scala/knobs/ZookeeperTest.scala
+++ b/zookeeper/src/test/scala/knobs/ZookeeperTest.scala
@@ -65,10 +65,9 @@ object ZooKeeperTests extends Properties("ZooKeeper") {
           ref.write(n.toInt).flatMap(_ => Task.delay(latch.countDown))
         case _ => Task.delay(latch.countDown)
       })
-      _ <- Task {
-        c.setData.forPath("/knobs.cfg", "foo = 20\n".toArray.map(_.toByte))
-        latch.await
-      }
+      _ <- Task.delay(Thread.sleep(1000))
+      _ <- Task.delay(c.setData.forPath("/knobs.cfg", "foo = 20\n".toArray.map(_.toByte)))
+      _ <- Task.delay(latch.await)
       n2 <- ref.read
     } yield n1 == 10 && n2 == 20
     val r = prg.unsafePerformSync


### PR DESCRIPTION
I had a quick look at this, as this is the final dependency preventing us from moving to 2.12.

I couldn't get to the bottom of the issue, but fundamentally, there appears to be a race condition between subscribing and updating a value, causing a deadlock in the zookeeper test. Adding a sleep between the subscribe and update (which, FWIW, the FileWatcherTest is also doing), appears to remove the deadlock.

I'd rather have got to the bottom of the problem and not have a sleep, but it might be worth considering this to get a 2.12 release.